### PR TITLE
修复IE7/6无图标仍占位bug

### DIFF
--- a/index.css
+++ b/index.css
@@ -42,7 +42,8 @@
 
 /* 没有小图标的 */
 .ui-list-nosquare {
-    list-style: none;    
+    list-style: none;   
+    +list-style-position:outside; 
 }
 
 /* ui-dlist */


### PR DESCRIPTION
修复IE7、IE6下 class="ui-list-nosquare" 列表无图标，但仍存在占位bug
